### PR TITLE
Expose glean as a library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,13 @@
 // swift-tools-version:5.4
 import PackageDescription
-
+let gleanChecksum = "b46cc53ca927f9de76ff6da9a9e444ac163b4b0abd4fc8dfd5ac0e612ca19254"
+let gleanVersion = "41.1.1"
+let gleanUrl = "https://github.com/mozilla/glean/releases/download/v\(gleanVersion)/Glean.xcframework.zip"
 let package = Package(
     name: "MozillaRustComponentsSwift",
     platforms: [.iOS(.v11)],
     products: [
+        .library(name: "Glean", targets: ["Glean"]),
         .library(name: "RustLog", targets: ["RustLog"]),
         .library(name: "Viaduct", targets: ["Viaduct"]),
         .library(name: "Nimbus", targets: ["Nimbus"]),
@@ -16,8 +19,6 @@ let package = Package(
         .library(name: "Tabs", targets: ["Tabs"]),
     ],
     dependencies: [
-        // TODO: ship Glean via this same bundle?
-        .package(name: "Glean", url: "https://github.com/mozilla/glean-swift", from: "41.1.1"),
         .package(name: "SwiftKeychainWrapper", url: "https://github.com/jrendel/SwiftKeychainWrapper", from: "4.0.1")
     ],
     targets: [
@@ -46,6 +47,7 @@ let package = Package(
             //
             //path: "./MozillaRustComponents.xcframework"
         ),
+        .binaryTarget(name: "Glean", url: gleanUrl, checksum: gleanChecksum),
         .target(
             name: "Sync15",
             path: "external/application-services/components/sync15/ios"


### PR DESCRIPTION
This is for adding glean as an exposed library to our `rust-components-swift`. The change is very simple, it basically does what https://github.com/mozilla/glean-swift does and is meant to replace it for consumers, so we can ensure there is only one version of glean our consumers get

There is still one part missing from this change that I'll add, and that's the scripts. in `glean-swift` there is a [useful script that updates the version, computes the checksum and creates a tag](https://github.com/mozilla/glean-swift/blob/main/bin/update.sh), we have a [script ourselves that does similar things](https://github.com/mozilla/rust-components-swift/blob/main/make_tag.sh) (minus the upgrading the version and computing the checksum, but it can very well do so)

I am very open to feedback here, and if there are any other ways to do this (expose Glean) or other suggestions to make this easier, I'll happily take them!

cc: @badboy , this won't merge yet, I'll get to the scripts on my Tuesday (Monday is a Canadian Holiday!) but cc'ing you in case you have any thoughts or opinions on the general direction