### PR TITLE
Updates glean to 42.0.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     ],
     dependencies: [
         // TODO: ship Glean via this same bundle?
-        .package(name: "Glean", url: "https://github.com/mozilla/glean-swift", from: "41.1.1"),
+        .package(name: "Glean", url: "https://github.com/mozilla/glean-swift", from: "42.0.1"),
         .package(name: "SwiftKeychainWrapper", url: "https://github.com/jrendel/SwiftKeychainWrapper", from: "4.0.1"),
         .package(name: "SwiftProtobuf", url: "https://github.com/apple/swift-protobuf", from: "1.18.0")
     ],


### PR DESCRIPTION
Updates glean to 42.0.1 so @travis79 can validate something in Focus, once this merges I'll cut a `rust-components-swift` release and update it on focus