### PR TITLE
Download protoc in CI

### DIFF
--- a/.github/workflows/update-as.yml
+++ b/.github/workflows/update-as.yml
@@ -4,7 +4,8 @@ name: Create a PR for release with the newest A-S version available
 on:
   schedule:
   # Runs every minute of the 3pm UTC hour of each day
-  - cron: '* 15 * * *'
+  - cron: '0 15 * * *'
+  workflow_dispatch:
 
 jobs:
   release-pr:
@@ -68,10 +69,12 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           source $HOME/.cargo/env
-      - name: Install swiftformat to format the uniffi generated bindings
+      - name: Install make_tag dependencies
         if: env.ALREADY_CREATED == 'false'
         run: |
           brew install swiftformat
+          brew install protobuf
+          brew install swift-protobuf
       # We strip away the `v` in the AS Version and run the make_tag
       # script, which will generate all the code that needs to be generated
       # Note that the tag argument isn't useful here, since we will


### PR DESCRIPTION
[The run this morning failed because with Places added, we added `protoc` and a swift protocol buffer generator to our `make_tag` script](https://github.com/mozilla/rust-components-swift/runs/3896965536?check_suite_focus=true) - this PR downloads those in our CI environment. It also reduces the frequency to only once at 8am PST (as opposed to every 5 minutes of the hour) and it allows the job to be manually triggered, this can be useful in case we want to expedite a release PR