### PR TITLE
Removes Application services submodule

### DIFF
--- a/.github/workflows/update-as.yml
+++ b/.github/workflows/update-as.yml
@@ -47,17 +47,6 @@ jobs:
           git config user.email "sync-team@mozilla.com"
           git config user.name "Firefox Sync Engineering"
           git checkout -b update-as-to-${{ env.AS_VERSION }}
-
-      # Update the submodule if we haven't ran those jobs yet
-      # note that we commit here
-      - name: Update the submodule to the release application services
-        if: env.ALREADY_CREATED == 'false'
-        run: |
-          cd external/application-services
-          git fetch --all --tags
-          git checkout $AS_VERSION
-          cd ../..
-          git commit -am "Updates application services submodule to $AS_VERSION"
       - name: Update Package.swift with new xcframework URL and checksum
         if: env.ALREADY_CREATED == 'false'
         run: |
@@ -83,7 +72,7 @@ jobs:
       - name: Runs make_tag script
         if: env.ALREADY_CREATED == 'false'
         run: |
-          ./make_tag.sh ${AS_VERSION:1}
+          ./make_tag.sh --as-version ${{ env.AS_VERSION }} ${AS_VERSION:1}
       - name: Create Pull Request
         if: env.ALREADY_CREATED == 'false'
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "external/application-services"]
-	path = external/application-services
-	url = https://github.com/mozilla/application-services

--- a/Package.swift
+++ b/Package.swift
@@ -51,17 +51,17 @@ let package = Package(
         ),
         .target(
             name: "Sync15",
-            path: "external/application-services/components/sync15/ios"
+            path: "generated/sync15"
         ),
         .target(
             name: "RustLog",
             dependencies: ["MozillaRustComponentsWrapper"],
-            path: "external/application-services/components/rc_log/ios"
+            path: "generated/rc_log"
         ),
         .target(
             name: "Viaduct",
             dependencies: ["MozillaRustComponentsWrapper"],
-            path: "external/application-services/components/viaduct/ios"
+            path: "generated/viaduct"
         ),
         .target(
             name: "Nimbus",

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ and its release artifacts:
 
 Key points:
 
-* The `rust-components-swift` repo includes the `application-services` repo as a git submodule.
 * The `application-services` repo publishes a binary artifact `MozillaRustComponents.xcframework.zip` containing
   the Rust code and FFI definitions for all components, compiled together into a single library.
 * The `Package.swift` file references `MozillaRustComponents.xcframework.zip` as a Swift binary target.
@@ -43,9 +42,8 @@ Key points:
 Whenever a new release of the underlying components is availble, we need to tag a new release
 in this repo to make them available to Swift components. To do so:
 
-* Update the git submodule under `./external` to the new release of the underlying components.
 * Edit `Package.swift` to update the URL and checksum of `MozillaRustComponents.xcframework.zip`.
-* Run `./make_tag.sh X.Y.Z` to create the new tag.
+* Run `./make_tag.sh --as-version {APP_SERVICES_VERSION} X.Y.Z` to create the new tag.
 * Run `git push origin X.Y.Z` to publish it to GitHub.
 
 ## Adding a new component
@@ -54,7 +52,6 @@ To add a new component to be distributed via this repo, you'll need to:
 
 * Add its Rust code and `.h` files to the build for the `MozillaRustComponents.xcframework.zip` bundle,
   following the docs for the [`ios-rust` crate](https://github.com/mozilla/application-services/tree/main/megazords/ios).
-* Add the source for the component to this repository as a git submodule under `./external`.
 * If the component needs to dynamically generate any Swift code (e.g. for UniFFI bindings, or Glean metrics),
   add logic for doing so to the `./generate.sh` script in this repository.
     * Swift packages can't dynamically generate code at build time, so we use the `./generate.sh` script
@@ -85,6 +82,12 @@ To test out some local changes to this repo:
       any adverse consequences if it does accidentally escape your local machine).
 * In a consuming application, delete the Swift Package dependency on `https://github.com/mozilla/rust-components-swift`
   and replace it with a dependency on `file:///path/to/your/local/checkout/rust-components-swift` at the `0.0.` release.
+
+### Testing against a local application-services checkout
+To run against a local application services checkout, the `make_tag.sh` script supports setting a local path using a `-l` flag, for example:
+```sh
+./make_tag -l ../application-services 0.0.1
+```
 
 That's it! The consuming application should be able to import the package from your local checkout.
 

--- a/external/README.md
+++ b/external/README.md
@@ -1,1 +1,0 @@
-Subdirectory for git submodules.

--- a/generate.sh
+++ b/generate.sh
@@ -13,7 +13,7 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 if [ -n "$1" ]; then
 APP_SERVICES_DIR=$1
 else
-APP_SERVICES_DIR="$THIS_DIR/external/application-services"
+APP_SERVICES_DIR="$THIS_DIR/application-services"
 fi
 
 UNIFFI_BINDGEN=(cargo run --manifest-path "$APP_SERVICES_DIR/tools/embedded-uniffi-bindgen/Cargo.toml")
@@ -123,3 +123,40 @@ protoc --proto_path="$APP_SERVICES_DIR/components/places/src" --swift_out="$PLAC
 
 # Copy the hand-written Swift, since it all needs to be together in one directory.
 cp -r "$APP_SERVICES_DIR/components/places/ios/Places" "$PLACES_DIR/Places"
+
+###
+#
+# Sync15
+#
+###
+
+SYNC15_DIR="$THIS_DIR/generated/sync15"
+rm -rf "$SYNC15_DIR" && mkdir -p "$SYNC15_DIR"
+
+# We only need to copy the hand-written Swift, sync15 does not use `uniffi` yet
+cp -r "$APP_SERVICES_DIR/components/sync15/ios/" $SYNC15_DIR
+
+###
+#
+# RustLog
+#
+###
+
+RUST_LOG_DIR="$THIS_DIR/generated/rc_log"
+rm -rf "$RUST_LOG_DIR" && mkdir -p "$RUST_LOG_DIR"
+
+# We only need to copy the hand-written Swift, RustLog does not use `uniffi` yet
+cp -r "$APP_SERVICES_DIR/components/rc_log/ios/" $RUST_LOG_DIR
+
+
+###
+#
+# Viaduct
+#
+###
+
+VIADUCT_DIR="$THIS_DIR/generated/viaduct"
+rm -rf "$VIADUCT_DIR" && mkdir -p "$VIADUCT_DIR"
+
+# We only need to copy the hand-written Swift, Viaduct does not use `uniffi` yet
+cp -r "$APP_SERVICES_DIR/components/viaduct/ios/" $VIADUCT_DIR

--- a/generated/rc_log/RustLog.swift
+++ b/generated/rc_log/RustLog.swift
@@ -1,0 +1,250 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+#if canImport(MozillaRustComponents)
+    import MozillaRustComponents
+#endif
+
+/// The level of a log message
+public enum LogLevel: Int32 {
+    /// The log message in question is verbose information which
+    /// may contain user PII.
+    case trace = 2
+    /// The log message in question is verbose information,
+    /// but should contain no PII.
+    case debug
+    /// The log message is informational
+    case info
+    /// The log message is a warning
+    case warn
+    /// The log message indicates an error.
+    case error
+
+    init(safeRawValue value: Int32) {
+        if let result = LogLevel(rawValue: value) {
+            self = result
+            return
+        }
+
+        if value < LogLevel.trace.rawValue {
+            self = .trace
+        } else {
+            self = .error
+        }
+    }
+}
+
+/// An enum representing a maximum log level. It is used with
+/// `RustLog.shared.setLevelFilter`.
+///
+/// This is roughly equivalent to LogLevel, however contains
+/// `Off`, for filtering all logging.
+public enum LogLevelFilter: Int32 {
+    /// Disable all logging
+    case off
+    /// Only allow `error` logs.
+    case error
+    /// Allow `warn` and `error` logs.
+    case warn
+    /// Allow `warn`, `error`, and `info` logs.
+    case info
+    /// Allow `warn`, `error`, `info`, and `debug` logs. The default.
+    case debug
+    /// Allow all logs, including those that may contain PII.
+    case trace
+}
+
+/// The type of the log callback. You can provide a value of this type to
+/// `RustLog.shared.enable` or `RustLog.shared.tryEnable`, and it will be called for
+/// all log messages emitted by Rust code.
+///
+/// The first argument is the level of the log. The maximum value of this can
+/// be provided using the `RustLog.shared.setLevelFilter` method.
+///
+/// The second argument is the tag, which is typically a rust module path
+/// string. It might be nil in some cases that aren't documented by the
+/// underlying rust log crate.
+///
+/// The last argument is the log message. It will not be nil.
+///
+/// This callback should return `true` to indicate everything is fine, and
+/// false if we should disable the logger. You cannot call `disable()`
+/// from inside the callback (it's protected by a dispatch queue you're
+/// already running on).
+public typealias LogCallback = (_ level: LogLevel, _ tag: String?, _ message: String) -> Bool
+
+/// The public interface to Rust's logger.
+///
+/// This is a singleton, and should be used via the
+/// `shared` static member.
+public class RustLog {
+    fileprivate let state = RustLogState()
+    fileprivate let queue = DispatchQueue(label: "com.mozilla.appservices.rust-log")
+    /// The singleton instance of RustLog
+    public static let shared = RustLog()
+
+    private init() {}
+
+    /// True if the logger currently has a bound callback.
+    public var isEnabled: Bool {
+        return queue.sync { state.isEnabled }
+    }
+
+    /// Set the current log callback.
+    ///
+    /// Note that by default, after enabling the level filter
+    /// will be at the `debug` level. If you want to increase or decrease it,
+    /// you may use `setLevelFilter`
+    ///
+    ///
+    /// See alse `tryEnable`.
+    ///
+    /// Throws:
+    ///
+    /// - `RustLogError.alreadyEnabled`: If we're already enabled. Explicitly disable first.
+    ///
+    /// - `RustLogError.unexpectedError`: If the rust code panics. This shouldn't happen,
+    ///   but if it does, we would appreciate reports from telemetry or similar
+    public func enable(_ callback: @escaping LogCallback) throws {
+        try queue.sync {
+            try state.enable(callback)
+        }
+    }
+
+    /// Set the level filter (the maximum log level) of the logger.
+    ///
+    /// Throws:
+    /// - `RustLogError.unexpectedError`: If the rust code panics. This shouldn't happen,
+    ///   but if it does, we would appreciate reports from telemetry or similar
+    public func setLevelFilter(filter: LogLevelFilter) throws {
+        // Note: Doesn't need to synchronize.
+        try rustCall { error in
+            rc_log_adapter_set_max_level(filter.rawValue, error)
+        }
+    }
+
+    /// Disable the previously set logger. This also sets the level filter to `.off`.
+    ///
+    /// Does nothing if the logger is disabled
+    public func disable() {
+        queue.sync {
+            state.disable()
+        }
+    }
+
+    /// Enable the logger if possible.
+    ///
+    /// Returns false in the cases where `enable` would throw, true otherwise.
+    ///
+    /// If it would throw due to a panic, it also writes some information about
+    /// the panic to the provided callback
+    public func tryEnable(_ callback: @escaping LogCallback) -> Bool {
+        return queue.sync {
+            state.tryEnable(callback)
+        }
+    }
+
+    /// Log a test message at `.info` severity.
+    public func logTestMessage(message: String) {
+        rc_log_adapter_test__log_msg(message)
+    }
+}
+
+/// The type of errors reported by RustLog. These either indicate bugs
+/// in our logging code (as in `UnexpectedError`), or usage errors
+/// (as in `AlreadyEnabled`)
+public enum RustLogError: Error {
+    /// This generally means a panic occurred, or something went very wrong.
+    /// We would appreciate bug reports about when these appear in the wild, if they do.
+    case unexpectedError(message: String)
+
+    /// Error indicating that the log adapter cannot be enabled
+    /// because it is already enabled.
+    ///
+    /// This is a usage error, either `disable` it first, or
+    /// use `RustLog.shared.tryEnable`
+    case alreadyEnabled
+}
+
+@discardableResult
+private func rustCall<T>(_ callback: (UnsafeMutablePointer<RcLogError>) throws -> T) throws -> T {
+    var err = RcLogError(code: 0, message: nil)
+    let result = try callback(&err)
+    if err.code != 0 {
+        let message: String
+        if let messageP = err.message {
+            defer { rc_log_adapter_destroy_string(messageP) }
+            message = String(cString: messageP)
+        } else {
+            message = "Bug: No message provided with code \(err.code)!"
+        }
+        throw RustLogError.unexpectedError(message: message)
+    }
+    return result
+}
+
+// This is the function actually passed to Rust.
+private func logCallbackFunc(level: Int32, optTagP: UnsafePointer<CChar>?, msgP: UnsafePointer<CChar>) {
+    guard let callback = RustLog.shared.state.callback else {
+        return
+    }
+    let msg = String(cString: msgP)
+    // Probably a better way to do this...
+    let tag: String?
+    if let optTagP = optTagP {
+        tag = String(cString: optTagP)
+    } else {
+        tag = nil
+    }
+    RustLog.shared.queue.async {
+        if !callback(LogLevel(safeRawValue: level), tag, msg) {
+            RustLog.shared.state.disable()
+        }
+    }
+}
+
+// This implements everything, but without synchronization. It needs to be
+// guarded by a queue, which is done by the RustLog class.
+private class RustLogState {
+    var adapter: OpaquePointer?
+    var callback: LogCallback?
+
+    var isEnabled: Bool { return adapter != nil }
+
+    func enable(_ callback: @escaping LogCallback) throws {
+        if isEnabled {
+            throw RustLogError.alreadyEnabled
+        }
+        assert(self.callback == nil)
+        self.callback = callback
+        adapter = try rustCall { error in
+            rc_log_adapter_create(logCallbackFunc, error)
+        }
+    }
+
+    func disable() {
+        guard let adapter = adapter else {
+            return
+        }
+        self.adapter = nil
+        callback = nil
+        rc_log_adapter_destroy(adapter)
+    }
+
+    func tryEnable(_ callback: @escaping LogCallback) -> Bool {
+        if isEnabled {
+            return false
+        }
+        do {
+            try enable(callback)
+            return true
+        } catch {
+            _ = callback(.error,
+                         "RustLog.swift",
+                         "RustLog.enable failed: \(error)")
+            return false
+        }
+    }
+}

--- a/generated/rc_log/RustLogFFI.h
+++ b/generated/rc_log/RustLogFFI.h
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+#include <stdint.h>
+#include <Foundation/NSObjCRuntime.h>
+
+typedef struct RcLogError {
+    int32_t code;
+    char *_Nullable message;
+} RcLogError;
+
+typedef void RustLogCallback(int32_t level,
+                             char const *_Nullable tag,
+                             char const *_Nonnull msg);
+
+typedef struct RustLogAdapter RustLogAdapter;
+
+RustLogAdapter *_Nullable rc_log_adapter_create(RustLogCallback *_Nonnull callback,
+                                                RcLogError *_Nonnull out_err);
+
+void rc_log_adapter_set_max_level(int32_t max_level,
+                                  RcLogError *_Nonnull out_err);
+
+void rc_log_adapter_destroy(RustLogAdapter *_Nonnull to_destroy);
+
+void rc_log_adapter_test__log_msg(char const *_Nonnull msg);
+
+// Only use for Error strings!
+void rc_log_adapter_destroy_string(char *_Nonnull msg);

--- a/generated/sync15/ResultError.swift
+++ b/generated/sync15/ResultError.swift
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+enum ResultError: Error {
+    case empty
+}

--- a/generated/sync15/SyncUnlockInfo.swift
+++ b/generated/sync15/SyncUnlockInfo.swift
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import UIKit
+
+/// Set of arguments required to sync.
+open class SyncUnlockInfo {
+    public var kid: String
+    public var fxaAccessToken: String
+    public var syncKey: String
+    public var tokenserverURL: String
+
+    public init(kid: String, fxaAccessToken: String, syncKey: String, tokenserverURL: String) {
+        self.kid = kid
+        self.fxaAccessToken = fxaAccessToken
+        self.syncKey = syncKey
+        self.tokenserverURL = tokenserverURL
+    }
+}

--- a/generated/viaduct/RustViaductFFI.h
+++ b/generated/viaduct/RustViaductFFI.h
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+#include <stdint.h>
+#include <Foundation/NSObjCRuntime.h>
+
+void viaduct_use_reqwest_backend();

--- a/generated/viaduct/Viaduct.swift
+++ b/generated/viaduct/Viaduct.swift
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+#if canImport(MozillaRustComponents)
+    import MozillaRustComponents
+#endif
+
+/// The public interface to viaduct.
+/// Right now it doesn't do any "true" viaduct things,
+/// it simply activated the reqwest backend.
+///
+/// This is a singleton, and should be used via the
+/// `shared` static member.
+public class Viaduct {
+    /// The singleton instance of Viaduct
+    public static let shared = Viaduct()
+
+    private init() {}
+
+    public func useReqwestBackend() {
+        // Note: Doesn't need to synchronize since
+        // use_reqwest_backend is backend by a CallOnce.
+        viaduct_use_reqwest_backend()
+    }
+}


### PR DESCRIPTION
Instead of the submodule, we do something _slightly_ hacky:
- we clone application services from github, on a specific version/checkout (this works for both tags and branches)
- we run our scripts and copy over any swift files we need
- once all is done, we delete `application-services` so we don't ship the whole project
- To make things a little easier, it adds the option to pass a `-l` and a path to a local checkout of application services and `make_tag.sh` will avoid cloning `application-services` all together, and just use your own version of it!

This should be a good win, so that we don't ship all of application-services with our swift package, and instead only use it to get what we need and dump it