### PR TITLE
Fixes copy of xcframework to allow repeatablility

### DIFF
--- a/appservices_local_xcframework.sh
+++ b/appservices_local_xcframework.sh
@@ -118,7 +118,7 @@ pushd $APP_SERVICES_DIR/megazords/ios-rust/
 popd
 
 ## Once built, we want to move the frameowork to this repository, then unzip it
-mv $APP_SERVICES_DIR/megazords/ios-rust/MozillaRustComponents.xcframework $THIS_DIR/MozillaRustComponents.xcframework
+rsync -a --delete $APP_SERVICES_DIR/megazords/ios-rust/MozillaRustComponents.xcframework/ $THIS_DIR/MozillaRustComponents.xcframework/
 
 ## We replace the url and checksum in the Package.swift with a refernce to the local
 ## framework path


### PR DESCRIPTION
When repeating the local script multiple times without deleteing/reseting it doesn't work as expected, this patch fixes that (by using `rsync` and correctly copying the directory