### PR TITLE
Add tabs generation logic for the tabs iOS integration

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -79,7 +79,7 @@ cp -r "$APP_SERVICES_DIR/components/logins/ios/Logins" "$OUT_DIR"
 # Autofill
 #
 ###
-## Not of our consumers currently use autofill, and the swift code has a name conflict with
+## None of our consumers currently use autofill, and the swift code has a name conflict with
 ## another component, so for now, commented out.
 
 # "${UNIFFI_BINDGEN[@]}" generate -l swift -o "$OUT_DIR/Generated" "$APP_SERVICES_DIR/components/autofill/src/autofill.udl"
@@ -98,10 +98,11 @@ cp -r "$APP_SERVICES_DIR/components/logins/ios/Logins" "$OUT_DIR"
 # Tabs
 #
 ###
-## Not of our consumers currently use tabs, and the swift code has a name conflict with
-## another component, so for now, commented out.
 
-# "${UNIFFI_BINDGEN[@]}" generate -l swift -o "$OUT_DIR/Generated" "$APP_SERVICES_DIR/components/tabs/src/tabs.udl"
+"${UNIFFI_BINDGEN[@]}" generate -l swift -o "$OUT_DIR/Generated" "$APP_SERVICES_DIR/components/tabs/src/tabs.udl"
+
+# Copy the hand-written Swift, since it all needs to be together in one directory.
+cp -r "$APP_SERVICES_DIR/components/tabs/ios/Tabs" "$OUT_DIR"
 
 ###
 #


### PR DESCRIPTION
This PR adds logic to generate the tabs logic for iOS. It should not be merged until an application services release has been cut that includes [AS #4905](https://github.com/mozilla/application-services/pull/4905). This PR also blocks [Firefox iOS PR #10553](https://github.com/mozilla-mobile/firefox-ios/pull/10553).