### PR TITLE
Updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ For more information, please consult:
   which describes the overall plan for distributing Rust-based components as Swift packages.
 * The [Swift Package Manager docs](https://swift.org/package-manager/) and [GitHub repo](https://github.com/apple/swift-package-manager),
   which explain the details of how Swift Packages work (and hence why this repo is set up the way it is).
-* The [`ios-rust` crate](https://github.com/mozilla/application-services/tree/main/megazords/ios) which is currently
-  responsible for publishing the pre-built `MozillaRustComponents.xcframework.zip` bundle on which this
-  repository depends.
+* The [`ios-rust` crate](https://github.com/mozilla/application-services/tree/main/megazords/ios-rust) which is currently
+  responsible for publishing the pre-built `MozillaRustComponents.xcframework.zip` and `FocusRustComponents.xcframework.zip` bundles on which this repository depends.
 
 ## Overview
 
@@ -30,12 +29,12 @@ and its release artifacts:
 
 Key points:
 
-* The `application-services` repo publishes a binary artifact `MozillaRustComponents.xcframework.zip` containing
+* The `application-services` repo publishes two binary artifacts `MozillaRustComponents.xcframework.zip` and `FocusRustComponents.xcframework.zip` containing
   the Rust code and FFI definitions for all components, compiled together into a single library.
-* The `Package.swift` file references `MozillaRustComponents.xcframework.zip` as a Swift binary target.
-* The `Package.swift` file defines an individual module for the Swift wrapper code of each component.
-    * Each module references its Swift source code directly as files in the repo.
-    * Each module depends on `MozillaRustComponentsWrapper` which wraps `MozillaRustComponents` to provide the pre-compiled Rust code.
+* The `Package.swift` file refrences the xcframeworks as Swift binary targets.
+* The `Package.swift` file defines a library per target (one for all the components used by `firefox-ios` and one for `focus-ios`)
+    * Each library references its Swift source code directly as files in the repo. All components used by a target are copied into the same directory. For example, all the `firefox-ios` files are in the `swift-source/all` directory.
+    * Each library depends on wrapper which wraps the binary to provide the pre-compiled Rust code. For example, [`FocusRustComponentWrapper`](./FocusRustComponentsWrapper/) wraps the Focus xcframework.
 
 ## Cutting a new release
 
@@ -48,46 +47,8 @@ in this repo to make them available to Swift components. To do so:
 
 ## Adding a new component
 
-To add a new component to be distributed via this repo, you'll need to:
+Check out the instructions in the [docs in `application-services` for adding a new component and publishing it for iOS](https://github.com/mozilla/application-services/blob/main/docs/howtos/adding-a-new-component.md#distribute-your-component-with-rust-components-swift). The docs are also published for convenience in <https://mozilla.github.io/application-services/book/index.html>.
 
-* Add its Rust code and `.h` files to the build for the `MozillaRustComponents.xcframework.zip` bundle,
-  following the docs for the [`ios-rust` crate](https://github.com/mozilla/application-services/tree/main/megazords/ios).
-* If the component needs to dynamically generate any Swift code (e.g. for UniFFI bindings, or Glean metrics),
-  add logic for doing so to the `./generate.sh` script in this repository.
-    * Swift packages can't dynamically generate code at build time, so we use the `./generate.sh` script
-      to do it ahead-of-time when publishing a release.
-* Edit `./Package.swift` to add the new component.
-    * Add a new library product for the component under "products".
-    * Add a corresponding target for the component under "targets".
-        * Make sure it depends on "MozillaRustComponentsWrapper" to pull in the pre-compiled Rust code,
-          as well as on any third-party Swift packages that it may require.
-* Follow the instructions below to test it out locally.
 
-That's it! The component will be included in the next release of this package.
-
-## Testing locally
-
-Swift Packages can only be installed from a git repository, but luckily it is possible to use a
-local checkout for a git repository for local testing.
-
-You may also need to follow the instructions for [locally testing the `ios-rust` crate](
-https://github.com/mozilla/application-services/blob/f3228cf1295154d144be64fc0945c9b3e93a07de/megazords/ios-rust/README.md#testing-locally)
-if you need to test changes in the underlying Rust code.
-
-To test out some local changes to this repo:
-
-* Make your changes in a local checkout and commit them.
-* Make a new tag via `./make_tag.sh -f 0.0.1`.
-    * (You won't push this tag anywhere, but using a very low version number helps guard against
-      any adverse consequences if it does accidentally escape your local machine).
-* In a consuming application, delete the Swift Package dependency on `https://github.com/mozilla/rust-components-swift`
-  and replace it with a dependency on `file:///path/to/your/local/checkout/rust-components-swift` at the `0.0.` release.
-
-### Testing against a local application-services checkout
-To run against a local application services checkout, the `make_tag.sh` script supports setting a local path using a `-l` flag, for example:
-```sh
-./make_tag -l ../application-services 0.0.1
-```
-
-That's it! The consuming application should be able to import the package from your local checkout.
-
+## Testing
+For testing instructions, you can checkout the [docs in the `application-services`](https://github.com/mozilla/application-services/tree/main/docs/howtos) which are published for convenience in <https://mozilla.github.io/application-services/book/index.html>


### PR DESCRIPTION
This PR mostly removes duplicate docs from here and points readers to the documents in [application-services's docs](https://github.com/mozilla/application-services/tree/main/docs) as the docs here mostly duplicated those and keeping both up to date will be hard (as they already were outdated 🙃)

Also mentions that we now ship one library per target as opposed to per component