### PR TITLE
[WIP] Uncommented code to generate autofill bindings

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -79,10 +79,7 @@ cp -r "$APP_SERVICES_DIR/components/logins/ios/Logins" "$OUT_DIR"
 # Autofill
 #
 ###
-## None of our consumers currently use autofill, and the swift code has a name conflict with
-## another component, so for now, commented out.
-
-# "${UNIFFI_BINDGEN[@]}" generate -l swift -o "$OUT_DIR/Generated" "$APP_SERVICES_DIR/components/autofill/src/autofill.udl"
+"${UNIFFI_BINDGEN[@]}" generate -l swift -o "$OUT_DIR/Generated" "$APP_SERVICES_DIR/components/autofill/src/autofill.udl"
 
 ###
 #


### PR DESCRIPTION
This changeset will allow the autofill bindings to be generated. This PR cannot be merged until the changes in [a-s PR #5293](https://github.com/mozilla/application-services/pull/5293) are merged as it contains a fix for the `createKey` naming collision between autofill and logins that currently causes the autofill bindings generations script to fail.