### PR TITLE
[DO NOT MERGE] Added logic to generate sync manager bindings

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -83,6 +83,13 @@ cp -r "$APP_SERVICES_DIR/components/logins/ios/Logins" "$OUT_DIR"
 
 ###
 #
+# Sync Manager
+#
+###
+"${UNIFFI_BINDGEN[@]}" generate -l swift -o "$OUT_DIR/Generated" "$APP_SERVICES_DIR/components/sync_manager/src/syncmanager.udl"
+
+###
+#
 # Push
 #
 ###


### PR DESCRIPTION
This PR adds the code necessary to generate bindings for the sync manager component. It is dependent on [A-S PR #5359](https://github.com/mozilla/application-services/pull/5359) and should not be merged until an A-S release with those changes is available.