### PR TITLE
Update glean metrics generation to include sync telemetry

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -31,7 +31,7 @@ rm -rf "$FOCUS_DIR" && mkdir -p "$FOCUS_DIR"
 # Glean metrics.
 # Run this first, because it appears to delete any other .swift files in the output directory.
 # Also, it wants to be run from inside Xcode, so we set some env vars to fake it out.
-SOURCE_ROOT="$THIS_DIR" PROJECT="MozillaAppServices" "$GLEAN_GENERATOR" -o "$OUT_DIR/Generated/Metrics/" "$APP_SERVICES_DIR/components/nimbus/metrics.yaml"
+SOURCE_ROOT="$THIS_DIR" PROJECT="MozillaAppServices" "$GLEAN_GENERATOR" -o "$OUT_DIR/Generated/Metrics/" "$APP_SERVICES_DIR/components/nimbus/metrics.yaml" "$APP_SERVICES_DIR/components/sync_manager/metrics.yaml" "$APP_SERVICES_DIR/components/sync_manager/pings.yaml"
 
 
 
@@ -87,6 +87,8 @@ cp -r "$APP_SERVICES_DIR/components/logins/ios/Logins" "$OUT_DIR"
 #
 ###
 "${UNIFFI_BINDGEN[@]}" generate -l swift -o "$OUT_DIR/Generated" "$APP_SERVICES_DIR/components/sync_manager/src/syncmanager.udl"
+# Copy the hand-written Swift, since it all needs to be together in one directory.
+cp -r "$APP_SERVICES_DIR/components/sync_manager/ios/SyncManager" "$OUT_DIR"
 
 ###
 #


### PR DESCRIPTION
This PR supports [A-S PR #5479](https://github.com/mozilla/application-services/pull/5479) by exposing the hand-written sync manager swift code and generates the Glean SDK for the `ping.yaml` and `metrics.yaml` files where the sync telemetry now lives.