### PR TITLE
Nightly tweaks

### DIFF
--- a/.github/workflows/update-as-nightly.yml
+++ b/.github/workflows/update-as-nightly.yml
@@ -3,8 +3,8 @@ name: Create a PR for release with the newest A-S version available
 # Controls when the workflow will run
 on:
   schedule:
-  # Runs every minute of the 3pm UTC hour of each day
-  - cron: '0 15 * * *'
+  # Runs 8:00am UTC each day
+  - cron: '0 8 * * *'
   workflow_dispatch:
 
 jobs:

--- a/automation/update-from-application-services.py
+++ b/automation/update-from-application-services.py
@@ -26,6 +26,9 @@ def main():
         print(f"Tag {tag} already exists, quitting")
         sys.exit(1)
     update_source(version)
+    if repo_has_changes():
+        print("No changes detected, quitting")
+        sys.exit(1)
     subprocess.check_call([
         "git",
         "commit",
@@ -131,6 +134,15 @@ def swift_artifact_url(version, filename):
     return ("https://firefox-ci-tc.services.mozilla.com"
             "/api/index/v1/task/project.application-services.v2"
             f".swift.{version.app_services_version}/artifacts/public%2Fbuild%2F{filename}")
+
+def repo_has_changes():
+    result = subprocess.run([
+        "git",
+        "diff-index",
+        "--quiet",
+        "HEAD",
+    ])
+    return result.returncode != 0
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
- Change the schedule to run at 3am UTC.  Our last nightly finished at 1:30am -- this seems like enough of a delay to ensure the a-s build is finishing without waiting too long after.
- Don't try to make a commit if there are no changes in the source.