### PR TITLE
Nightly script: return 0 when no changes are detected

### DIFF
--- a/automation/update-from-application-services.py
+++ b/automation/update-from-application-services.py
@@ -28,7 +28,7 @@ def main():
     update_source(version)
     if not repo_has_changes():
         print("No changes detected, quitting")
-        sys.exit(1)
+        sys.exit(0)
     subprocess.check_call([
         "git",
         "commit",


### PR DESCRIPTION
This prevents the github workflow from showing up as red (https://github.com/mozilla/rust-components-swift/actions/runs/5119016999/jobs/9203740233)