### PR TITLE
Don't try to decompress nightly json artifact

### DIFF
--- a/automation/update-from-application-services.py
+++ b/automation/update-from-application-services.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from urllib.request import urlopen
 import argparse
 import fileinput
-import gzip
 import hashlib
 import json
 import subprocess
@@ -65,7 +64,7 @@ class VersionInfo:
         self.is_nightly = app_services_version == "nightly"
         if self.is_nightly:
             with urlopen(NIGHTLY_JSON_URL) as stream:
-                data = json.loads(gzip.decompress(stream.read()))
+                data = json.loads(stream.read())
                 app_services_version = data['version']
         components = app_services_version.split(".")
         if len(components) != 2:


### PR DESCRIPTION
Taskcluster no longer returns a gzipped file for the `json` file we use to get the nightly artifacts for rust-component-swift - I verified this works locally and the script ran to completion updating the `Package.swift` and `swift-source` as expected