### PR TITLE
Generate docs and files for static websites

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,114 @@
+name: Generate and Deploy Documentation
+
+on:
+  push:
+    branches:
+      - generate-docs # replace with main
+
+jobs:
+  build-docs:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Ensures all branches are fetched
+
+      - name: Select Xcode Command Line Tools 15.1
+        run: |
+          sudo xcode-select -s /Applications/Xcode_15.1.app/Contents/Developer
+
+      - name: Install Homebrew
+        run: |
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        shell: bash
+
+      - name: Clone application-services repository with submodules
+        run: |
+          git clone https://github.com/mozilla/application-services.git /tmp/application-services
+          cd /tmp/application-services
+          git submodule init
+          git submodule update --recursive
+
+      - name: Install Python, setuptools, six and gyp
+        run: |
+          brew install ninja python@3.9 python-setuptools
+          
+          # Create and activate a virtual environment
+          python3.9 -m venv myenv
+          source myenv/bin/activate
+          
+          # Upgrade pip and install setuptools and six within the virtual environment
+          pip install --upgrade pip setuptools six
+          
+          
+          wget https://bootstrap.pypa.io/ez_setup.py -O - | python3 -
+          git clone https://chromium.googlesource.com/external/gyp.git ~/tools/gyp
+          cd ~/tools/gyp
+          python3.9 setup.py install
+          
+          echo "export PATH=~/tools/gyp:\$PATH" >> ~/.bash_profile
+          echo 'export PATH="$PATH:$(brew --prefix)/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/bin"' >> ~/.bash_profile
+        shell: bash
+
+      - name: Setup iOS environment
+        run: |
+          # Activate the virtual environment
+          source myenv/bin/activate  
+          
+          # Copy over the build files without iOS-simulator and x86 targets
+          cp ./automation/build-docs/overwrites/build-all-ios.sh /tmp/application-services/libs/
+          cp ./automation/build-docs/overwrites/build-nss-ios.sh /tmp/application-services/libs/
+          cp ./automation/build-docs/overwrites/verify-ios-ci-environment.sh /tmp/application-services/libs/   
+          
+          # Overwrite how to build the swift code (without FirefoxFocus and x86 targets)
+          cp ./automation/build-docs/overwrites/build-and-test-swift.py /tmp/application-services/taskcluster/scripts/
+    
+          cp ./automation/build-docs/overwrites/build-xcframework.sh /tmp/application-services/megazords/ios-rust/
+          cd /tmp/application-services
+          ./libs/verify-ios-ci-environment.sh
+        shell: bash
+
+      - name: Build the XCFramework from application-services
+        run: |
+          cd ./automation/build-docs/
+          ./build_local_xcframework_for_docs.sh /tmp/application-services
+
+      - name: Build the documentation
+        run: |
+          cd ./automation/build-docs/
+          ./generate_docs.sh
+
+      - name: Upload Documentation as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: docs
+          path: ./automation/build-docs/docs-website
+
+  deploy-docs:
+    runs-on: ubuntu-latest
+    needs: build-docs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Ensures all branches are fetched
+
+      - name: Download Documentation
+        uses: actions/download-artifact@v3
+        with:
+          name: docs
+          path: ./automation/build-docs/docs-website
+
+      - name: Deploy to /docs Branch
+        run: |
+          git checkout --orphan docs
+          git reset --hard
+          cp -r ./automation/build-docs/docs-website* .
+          git add -A
+          git commit -m "Deploy documentation to /docs branch"
+          git push -f origin docs
+
+      - name: Clean up workspace
+        run: |
+          git checkout main

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -56,6 +56,9 @@ jobs:
           # Activate the virtual environment
           source myenv/bin/activate  
           
+          # Ensure clean build directory
+          rm -rf /tmp/application-services/build
+          
           # Copy over the build files without iOS-simulator and x86 targets
           cp ./automation/build-docs/overwrites/build-all-ios.sh /tmp/application-services/libs/
           cp ./automation/build-docs/overwrites/build-nss-ios.sh /tmp/application-services/libs/
@@ -63,8 +66,10 @@ jobs:
           
           # Overwrite how to build the swift code (without FirefoxFocus and x86 targets)
           cp ./automation/build-docs/overwrites/build-and-test-swift.py /tmp/application-services/taskcluster/scripts/
-    
+          
+          # Overwrite how to build the xcframework, without the focus app
           cp ./automation/build-docs/overwrites/build-xcframework.sh /tmp/application-services/megazords/ios-rust/
+          
           cd /tmp/application-services
           ./libs/verify-ios-ci-environment.sh
         shell: bash

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -85,6 +85,11 @@ jobs:
           name: docs
           path: ./automation/build-docs/docs-website
 
+      - name: Run rename and update script
+        run: |
+          cd ./automation/build-docs/
+          ./rename-and-update.sh
+
   deploy-docs:
     runs-on: macos-latest
     needs: build-docs

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -79,16 +79,16 @@ jobs:
           cd ./automation/build-docs/
           ./generate_docs.sh
 
+      - name: Run rename and update script
+        run: |
+          cd ./automation/build-docs/
+          ./rename-and-update.sh
+
       - name: Upload Documentation as Artifact
         uses: actions/upload-artifact@v3
         with:
           name: docs
           path: ./automation/build-docs/docs-website
-
-      - name: Run rename and update script
-        run: |
-          cd ./automation/build-docs/
-          ./rename-and-update.sh
 
   deploy-docs:
     runs-on: macos-latest

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -86,7 +86,7 @@ jobs:
           path: ./automation/build-docs/docs-website
 
   deploy-docs:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs: build-docs
     steps:
       - name: Checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,12 @@ Package.resolved
 
 # From the Glean sdk generator
 .venv
+
+# Docs generation
+/automation/build-docs/docs-website/
+/automation/build-docs/docs_output/
+/automation/build-docs/MozillaRustComponents.xcframework
+/automation/build-docs/build
+automation/build-docs/swift-source/
+
+.idea

--- a/automation/build-docs/MozillaRustComponentsWrapper/dummy.m
+++ b/automation/build-docs/MozillaRustComponentsWrapper/dummy.m
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+// Swift Package Manager needs at least one source file.

--- a/automation/build-docs/MozillaRustComponentsWrapper/include/dummy.h
+++ b/automation/build-docs/MozillaRustComponentsWrapper/include/dummy.h
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+// Swift Package Manager needs at least one header to prevent a warning. See
+// https://github.com/mozilla/application-services/issues/4422.

--- a/automation/build-docs/Package.swift
+++ b/automation/build-docs/Package.swift
@@ -1,0 +1,50 @@
+// swift-tools-version:5.5
+import PackageDescription
+
+let checksum = "0830da14106bd3068c8beb68cf6b4a5e0ce6251d40f31446c812ab18dc244de0"
+let version = "131.0.20240821050323"
+let url = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.131.20240821050323/artifacts/public/build/MozillaRustComponents.xcframework.zip"
+
+let package = Package(
+    name: "MozillaRustComponentsSwift",
+    platforms: [.iOS(.v15)],
+    products: [
+        .library(name: "MozillaAppServices", targets: ["MozillaAppServices"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/mozilla/glean-swift", from: "61.0.0")
+    ],
+    targets: [
+        /*
+        * A placeholder wrapper for our binaryTarget so that Xcode will ensure this is
+        * downloaded/built before trying to use it in the build process
+        * A bit hacky but necessary for now https://github.com/mozilla/application-services/issues/4422
+        */
+        .target(
+            name: "MozillaRustComponentsWrapper",
+            dependencies: [
+                .target(name: "MozillaRustComponents", condition: .when(platforms: [.iOS])),
+                .product(name: "Glean", package: "glean-swift")
+            ],
+            path: "MozillaRustComponentsWrapper"
+        ),
+        .binaryTarget(
+            name: "MozillaRustComponents",
+            //
+            // For release artifacts, reference the MozillaRustComponents as a URL with checksum.
+            // IMPORTANT: The checksum has to be on the line directly after the `url`
+            // this is important for our release script so that all values are updated correctly
+            path: "./MozillaRustComponents.xcframework"
+
+            // For local testing, you can point at an (unzipped) XCFramework that's part of the repo.
+            // Note that you have to actually check it in and make a tag for it to work correctly.
+            //
+            //path: "./MozillaRustComponents.xcframework"
+        ),
+        .target(
+            name: "MozillaAppServices",
+            dependencies: ["MozillaRustComponentsWrapper"],
+            path: "swift-source/all"
+        ),
+    ]
+)

--- a/automation/build-docs/build_local_xcframework_for_docs.sh
+++ b/automation/build-docs/build_local_xcframework_for_docs.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Uses a local version of application services xcframework
+
+# This script allows switches the usage of application services to a local xcframework
+# built from a local checkout of application services
+
+set -e
+
+# CMDNAME is used in the usage text below
+CMDNAME=$(basename "$0")
+USAGE=$(cat <<EOT
+${CMDNAME}
+Tarik Eshaq <teshaq@mozilla.com>
+
+Uses a local version of application services xcframework
+
+This script allows switches the usage of application services to a local xcframework
+built from a local checkout of application services
+
+
+USAGE:
+    ${CMDNAME} [OPTIONS] <LOCAL_APP_SERVICES_PATH>
+
+OPTIONS:
+    -d, --disable           Disables local development on application services
+    -h, --help              Display this help message.
+EOT
+)
+
+msg () {
+  printf "\033[0;34m> %s\033[0m\n" "${1}"
+}
+
+helptext() {
+    echo "$USAGE"
+}
+
+
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PACKAGE_FILE="$THIS_DIR/Package.swift"
+SWIFT_SOURCE="$THIS_DIR/swift-source"
+FRAMEWORK_PATH="./MozillaRustComponents.xcframework"
+FRAMEWORK_PATH_ESCAPED=$( echo $FRAMEWORK_PATH |  sed 's/\//\\\//g' )
+APP_SERVICES_REMOTE="https://github.com/mozilla/application-services"
+
+DISABLE="false"
+APP_SERVICES_DIR=
+while (( "$#" )); do
+    case "$1" in
+        -d|--disable)
+            DISABLE="true"
+            shift
+            ;;
+        -h|--help)
+            helptext
+            exit 0
+            ;;
+        --) # end argument parsing
+            shift
+            break
+            ;;
+        --*=|-*) # unsupported flags
+            echo "Error: Unsupported flag $1" >&2
+            exit 1
+            ;;
+        *) # preserve positional arguments
+            APP_SERVICES_DIR=$1
+            shift
+            ;;
+    esac
+done
+
+if [ "true" = $DISABLE ]; then
+  msg "Resetting $PACKAGE_FILE to use remote xcframework"
+  # We disable the local development and revert back
+  # ideally, users should just use git reset.
+  #
+  # This exist so local development can be easy to enable/disable
+  # and we trust that once developers are ready to push changes
+  # they will clean the files to make sure they are in the same
+  # state they were in before any of the changes happened.
+  perl -0777 -pi -e "s/            path: \"$FRAMEWORK_PATH_ESCAPED\"/            url: url,
+            checksum: checksum/igs" $PACKAGE_FILE
+
+  msg "Done reseting $PACKAGE_FILE"
+  git add $PACKAGE_FILE
+  msg "$PACKAGE_FILE changes staged"
+
+  if [ -d $FRAMEWORK_PATH ]; then
+    msg "Detected local framework, deleting it.."
+    rm -rf $FRAMEWORK_PATH
+    git add $FRAMEWORK_PATH
+    msg "Deleted and staged the deletion of the local framework"
+  fi
+  msg "IMPORTANT: reminder that changes to this repository are not visable to consumers until
+      commited"
+  exit 0
+fi
+
+if [ -z $APP_SERVICES_DIR ]; then
+    msg "Please set the application-services path."
+    msg "This is a path to a local checkout of the application services repository"
+    msg "You can find the repository on $APP_SERVICES_REMOTE"
+    exit 1
+fi
+
+## We replace the url and checksum in the Package.swift with a refernce to the local
+## framework path
+perl -0777 -pi -e "s/            url: url,
+            checksum: checksum/            path: \"$FRAMEWORK_PATH_ESCAPED\"/igs" $PACKAGE_FILE
+
+
+## First we build the xcframework in the application services repository
+msg "Building the xcframework in $APP_SERVICES_DIR"
+msg "This might take a few minutes"
+pushd $APP_SERVICES_DIR
+./taskcluster/scripts/build-and-test-swift.py "$SWIFT_SOURCE" "$THIS_DIR" "$THIS_DIR/build/glean-dir" --force_build
+popd
+unzip -o "$THIS_DIR/MozillaRustComponents.xcframework.zip" && rm "$THIS_DIR/MozillaRustComponents.xcframework.zip"
+
+rm -rf FocusRustComponents.xcframework.zip

--- a/automation/build-docs/generate_docs.sh
+++ b/automation/build-docs/generate_docs.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Define variables
+OUTPUT_DIR="./docs_output"
+
+SCHEME="MozillaRustComponentsSwift"
+DESTINATION="generic/platform=iOS"
+DOCC_NAME="MozillaAppServices"
+DOCC_ARCHIVE_PATH="$OUTPUT_DIR/Build/Products/Debug-iphoneos/$DOCC_NAME.doccarchive"
+STATIC_FILES_FOLDER="./docs-website"
+
+# Run xcodebuild to build documentation
+echo "Running xcodebuild for documentation generation..."
+xcodebuild docbuild -scheme $SCHEME -destination $DESTINATION -derivedDataPath $OUTPUT_DIR
+
+# Run xcrun to generate the final DocC archive
+echo "Running xcrun to generate DocC archive..."
+xcrun docc process-archive transform-for-static-hosting $DOCC_ARCHIVE_PATH --output-path $STATIC_FILES_FOLDER --hosting-base-path DOCC_NAME
+
+# Cleanup
+echo "Cleaning up..."
+rm -rf "swift-source"
+rm -rf "MozillaRustComponents.xcframework"
+
+echo "Documentation generation completed. Output available in $STATIC_FILES_FOLDER"

--- a/automation/build-docs/generate_docs.sh
+++ b/automation/build-docs/generate_docs.sh
@@ -8,6 +8,7 @@ DESTINATION="generic/platform=iOS"
 DOCC_NAME="MozillaAppServices"
 DOCC_ARCHIVE_PATH="$OUTPUT_DIR/Build/Products/Debug-iphoneos/$DOCC_NAME.doccarchive"
 STATIC_FILES_FOLDER="./docs-website"
+BASE_PATH_NAME="rust-components-swift"
 
 # Run xcodebuild to build documentation
 echo "Running xcodebuild for documentation generation..."
@@ -15,7 +16,7 @@ xcodebuild docbuild -scheme $SCHEME -destination $DESTINATION -derivedDataPath $
 
 # Run xcrun to generate the final DocC archive
 echo "Running xcrun to generate DocC archive..."
-xcrun docc process-archive transform-for-static-hosting $DOCC_ARCHIVE_PATH --output-path $STATIC_FILES_FOLDER --hosting-base-path DOCC_NAME
+xcrun docc process-archive transform-for-static-hosting $DOCC_ARCHIVE_PATH --output-path $STATIC_FILES_FOLDER --hosting-base-path $BASE_PATH_NAME
 
 # Cleanup
 echo "Cleaning up..."

--- a/automation/build-docs/overwrites/build-all-ios.sh
+++ b/automation/build-docs/overwrites/build-all-ios.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -euvx
+
+# This probably needs to be updated, but also includes the toolchain?
+IOS_MIN_SDK_VERSION="11.0"
+# Our short-names for the architectures.
+TARGET_ARCHS=("arm64")
+
+if [[ "${#}" -ne 1 ]]
+then
+    echo "Usage:"
+    echo "./build-all-ios.sh <NSS_SRC_PATH>"
+    exit 1
+fi
+
+NSS_SRC_PATH=${1}
+
+function universal_lib() {
+  DIR_NAME="${1}"
+  LIB_NAME="${2}"
+  shift; shift
+  UNIVERSAL_DIR="ios/universal/${DIR_NAME}"
+  LIB_PATH="${UNIVERSAL_DIR}/lib/${LIB_NAME}"
+  if [[ ! -e "${LIB_PATH}" ]]; then
+    mkdir -p "${UNIVERSAL_DIR}/lib"
+    CMD="lipo"
+    for ARCH in "${@}"; do
+      if [[ "${ARCH}" != "arm64-sim" ]]; then
+        CMD="${CMD} -arch ${ARCH} ios/${ARCH}/${DIR_NAME}/lib/${LIB_NAME}"
+      fi
+    done
+    CMD="${CMD} -output ${LIB_PATH} -create"
+    ${CMD}
+  fi
+}
+
+echo "# Building NSS"
+for i in "${!TARGET_ARCHS[@]}"; do
+  ARCH=${TARGET_ARCHS[${i}]}
+  DIST_DIR=$(abspath "ios/${ARCH}/nss")
+  if [[ -d "${DIST_DIR}" ]]; then
+    echo "${DIST_DIR} already exists. Skipping building nss."
+  else
+    ./build-nss-ios.sh "${NSS_SRC_PATH}" "${DIST_DIR}" "${ARCH}" "${IOS_MIN_SDK_VERSION}" || exit 1
+  fi
+done
+universal_lib "nss" "libcertdb.a" "${TARGET_ARCHS[@]}"
+universal_lib "nss" "libfreebl_static.a" "${TARGET_ARCHS[@]}"
+universal_lib "nss" "libnssb.a" "${TARGET_ARCHS[@]}"
+universal_lib "nss" "libnssutil.a" "${TARGET_ARCHS[@]}"
+universal_lib "nss" "libpkcs7.a" "${TARGET_ARCHS[@]}"
+universal_lib "nss" "libsmime.a" "${TARGET_ARCHS[@]}"
+universal_lib "nss" "libcerthi.a" "${TARGET_ARCHS[@]}"
+universal_lib "nss" "libnspr4.a" "${TARGET_ARCHS[@]}"
+universal_lib "nss" "libnssdev.a" "${TARGET_ARCHS[@]}"
+universal_lib "nss" "libpk11wrap_static.a" "${TARGET_ARCHS[@]}"
+universal_lib "nss" "libplc4.a" "${TARGET_ARCHS[@]}"
+universal_lib "nss" "libsoftokn_static.a" "${TARGET_ARCHS[@]}"
+universal_lib "nss" "libcryptohi.a" "${TARGET_ARCHS[@]}"
+universal_lib "nss" "libnss_static.a" "${TARGET_ARCHS[@]}"
+universal_lib "nss" "libnsspki.a" "${TARGET_ARCHS[@]}"
+universal_lib "nss" "libpkcs12.a" "${TARGET_ARCHS[@]}"
+universal_lib "nss" "libplds4.a" "${TARGET_ARCHS[@]}"
+universal_lib "nss" "libssl.a" "${TARGET_ARCHS[@]}"
+universal_lib "nss" "libgcm-aes-aarch64_c_lib.a" "arm64"
+universal_lib "nss" "libarmv8_c_lib.a" "arm64"
+
+HEADER_DIST_DIR="ios/universal/nss/include/nss"
+if [[ ! -e "${HEADER_DIST_DIR}" ]]; then
+  mkdir -p ${HEADER_DIST_DIR}
+  # Choice of arm64 is arbitrary, it shouldn't matter.
+  HEADER_SRC_DIR=$(abspath "ios/arm64/nss/include/nss")
+  cp -L "${HEADER_SRC_DIR}"/*.h "${HEADER_DIST_DIR}"
+fi
+
+echo "# Ensure Glean checkout"
+git submodule update --init

--- a/automation/build-docs/overwrites/build-and-test-swift.py
+++ b/automation/build-docs/overwrites/build-and-test-swift.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+
+from collections import namedtuple
+import argparse
+import subprocess
+import pathlib
+import os
+
+# Repository root dir
+ROOT_DIR = pathlib.Path(__file__).parent.parent.parent
+# List of udl_paths to generate bindings for
+BINDINGS_UDL_PATHS = [
+    "components/as-ohttp-client/src/as_ohttp_client.udl",
+    "components/autofill/src/autofill.udl",
+    "components/fxa-client/src/fxa_client.udl",
+    "components/logins/src/logins.udl",
+    "components/nimbus/src/nimbus.udl",
+    "components/places/src/places.udl",
+    "components/push/src/push.udl",
+    "components/remote_settings/src/remote_settings.udl",
+    "components/suggest/src/suggest.udl",
+    "components/support/error/src/errorsupport.udl",
+    "components/sync15/src/sync15.udl",
+    "components/sync_manager/src/syncmanager.udl",
+    "components/tabs/src/tabs.udl",
+    "components/support/rust-log-forwarder/src/rust_log_forwarder.udl",
+]
+
+
+# List of globs to copy the sources from
+SOURCE_TO_COPY = [
+    "components/as-ohttp-client/ios/ASOhttpClient",
+    "components/nimbus/ios/Nimbus",
+    "components/fxa-client/ios/FxAClient",
+    "components/logins/ios/Logins",
+    "components/tabs/ios/Tabs",
+    "components/places/ios/Places",
+    "components/sync15/ios/Sync15",
+    "components/sync_manager/ios/SyncManager",
+    "components/viaduct/ios/*",
+]
+
+
+def main():
+    args = parse_args()
+    ensure_dir(args.out_dir)
+    ensure_dir(args.xcframework_dir)
+    run_tests(args)
+    xcframework_build(args, "MozillaRustComponents.xcframework.zip")
+    generate_glean_metrics(args)
+    generate_uniffi_bindings(args)
+    copy_source_dirs(args)
+    log("build complete")
+
+def parse_args():
+    parser = argparse.ArgumentParser(prog='build-and-test-swift.py')
+    parser.add_argument('out_dir', type=pathlib.Path)
+    parser.add_argument('xcframework_dir', type=pathlib.Path)
+    parser.add_argument('glean_work_dir', type=pathlib.Path)
+    parser.add_argument('--force_build', action="store_true")
+    return parser.parse_args()
+
+def run_tests(args):
+    # FIXME: this is currently failing with `Package.resolved file is corrupted or malformed; fix or
+    # delete the file to continue`
+    # subprocess.check_call([
+    #     "automation/tests.py", "ios-tests"
+    # ])
+    pass
+
+XCFrameworkBuildInfo = namedtuple("XCFrameworkBuildInfo", "filename out_path build_command")
+XCFRAMEWORK_BUILDS = [
+    XCFrameworkBuildInfo(
+        'MozillaRustComponents.xcframework.zip',
+        'megazords/ios-rust/MozillaRustComponents.xcframework.zip',
+        [
+            'megazords/ios-rust/build-xcframework.sh',
+            '--build-profile',
+            'release',
+        ],
+    ),
+]
+
+def xcframework_build(args, filename):
+    for build_info in XCFRAMEWORK_BUILDS:
+        if build_info.filename == filename:
+            break
+    else:
+        raise LookupError(f"No XCFrameworkBuildInfo for {filename}")
+
+    # Build the XCFramework if it hasn't already been built (for example the `tests.py ios-tests`)
+    if not os.path.exists(build_info.out_path) or args.force_build:
+        subprocess.check_call(build_info.build_command)
+
+    # Copy the XCFramework to our output directory
+    subprocess.check_call(['cp', '-a', build_info.out_path, args.xcframework_dir])
+
+"""Generate Glean metrics.
+
+Run this first, because it appears to delete any other .swift files in the output directory.
+"""
+def generate_glean_metrics(args):
+    # Make sure there's a python venv for glean to use
+    venv_dir = args.glean_work_dir / '.venv'
+    if not venv_dir.exists():
+        log("setting up Glean venv")
+        subprocess.check_call(['python3', '-m', 'venv', str(venv_dir)])
+
+    log("Running Glean for nimbus")
+    # sdk_generator wants to be run from inside Xcode, so we set some env vars to fake it out.
+    env = {
+        'SOURCE_ROOT': str(args.glean_work_dir),
+        'PROJECT': "MozillaAppServices",
+        'GLEAN_PYTHON': '/usr/bin/env python3',
+        'LC_ALL': 'C.UTF-8',
+        'LANG': 'C.UTF-8',
+        'PATH': os.environ['PATH'],
+    }
+    glean_script = ROOT_DIR / "components/external/glean/glean-core/ios/sdk_generator.sh"
+    out_dir = args.out_dir / 'all' / 'Generated' / 'Metrics'
+    firefox_glean_files = map(str, [ROOT_DIR / "components/nimbus/metrics.yaml", ROOT_DIR / "components/sync_manager/metrics.yaml", ROOT_DIR / "components/sync_manager/pings.yaml"])
+    generate_glean_metrics_for_target(env, glean_script, out_dir, firefox_glean_files)
+
+def generate_glean_metrics_for_target(env, glean_script, out_dir, input_files):
+    ensure_dir(out_dir)
+    subprocess.check_call([
+        str(glean_script),
+        "-o", str(out_dir),
+        *input_files
+    ], env=env)
+
+def generate_uniffi_bindings(args):
+    out_dir = args.out_dir / 'all' / 'Generated'
+
+    ensure_dir(out_dir)
+
+    generate_uniffi_bindings_for_target(out_dir, BINDINGS_UDL_PATHS)
+
+def generate_uniffi_bindings_for_target(out_dir, bindings_path):
+    for udl_path in bindings_path:
+        log(f"generating sources for {udl_path}")
+        run_uniffi_bindgen(['generate', '-l', 'swift', '-o', out_dir, ROOT_DIR / udl_path])
+
+def run_uniffi_bindgen(bindgen_args):
+    all_args = [
+        'cargo', 'run', '-p', 'embedded-uniffi-bindgen',
+    ]
+    all_args.extend(bindgen_args)
+    subprocess.check_call(all_args, cwd=ROOT_DIR)
+
+def copy_source_dirs(args):
+    out_dir = args.out_dir / 'all'
+
+    copy_sources(out_dir, SOURCE_TO_COPY)
+
+def copy_sources(out_dir, sources):
+    ensure_dir(out_dir)
+    for source in sources:
+        log(f"copying {source}")
+        for path in ROOT_DIR.glob(source):
+            subprocess.check_call(['cp', '-r', path, out_dir])
+
+def ensure_dir(path):
+    if not path.exists():
+        os.makedirs(path)
+
+def log(message):
+    print()
+    print(f'* {message}', flush=True)
+
+if __name__ == '__main__':
+    main()

--- a/automation/build-docs/overwrites/build-nss-ios.sh
+++ b/automation/build-docs/overwrites/build-nss-ios.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+# This script cross-compiles the NSS library for iOS.
+
+set -euvx
+
+if [[ "${#}" -ne 4 ]]
+then
+    echo "Usage:"
+    echo "./build-nss-ios.sh <ABSOLUTE_SRC_DIR> <DIST_DIR> <ARCH> <IOS_MIN_SDK_VERSION>"
+    exit 1
+fi
+
+NSS_SRC_DIR=${1}
+DIST_DIR=${2}
+ARCH=${3}
+IOS_MIN_SDK_VERSION=${4}
+
+if [[ -d "${DIST_DIR}" ]]; then
+  echo "${DIST_DIR} folder already exists. Skipping build."
+  exit 0
+fi
+
+if [[ "${ARCH}" == "arm64" ]]; then
+  OS_COMPILER="iPhoneOS"
+  TARGET="aarch64-apple-darwin"
+  GYP_ARCH="arm64"
+  EXTRA_TARGET="arm64-apple-ios"
+else
+  echo "Unsupported architecture"
+  exit 1
+fi
+
+DEVELOPER=$(xcode-select -print-path)
+CROSS_TOP="${DEVELOPER}/Platforms/${OS_COMPILER}.platform/Developer"
+CROSS_SDK="${OS_COMPILER}.sdk"
+TOOLCHAIN_BIN="${DEVELOPER}/Toolchains/XcodeDefault.xctoolchain/usr/bin"
+ISYSROOT="${CROSS_TOP}/SDKs/${CROSS_SDK}"
+CC="${TOOLCHAIN_BIN}/clang -target ${EXTRA_TARGET} -arch ${ARCH} -isysroot ${ISYSROOT} -mios-version-min=${IOS_MIN_SDK_VERSION}"
+
+# Build NSPR
+NSPR_BUILD_DIR=$(mktemp -d)
+pushd "${NSPR_BUILD_DIR}"
+"${NSS_SRC_DIR}"/nspr/configure \
+  STRIP="${TOOLCHAIN_BIN}/strip" \
+  RANLIB="${TOOLCHAIN_BIN}/ranlib" \
+  AR="${TOOLCHAIN_BIN}/ar" \
+  AS="${TOOLCHAIN_BIN}/as" \
+  LD="${TOOLCHAIN_BIN}/ld" \
+  CC="${CC}" \
+  CCC="${CC}" \
+  --target "${TARGET}" \
+  --enable-64bit \
+  --disable-debug \
+  --enable-optimize
+make
+popd
+
+# Build NSS
+BUILD_DIR=$(mktemp -d)
+rm -rf "${NSS_SRC_DIR}/nss/out"
+gyp -f ninja "${NSS_SRC_DIR}/nss/nss.gyp" \
+  --depth "${NSS_SRC_DIR}/nss/" \
+  --generator-output=. \
+  -DOS=ios \
+  -Dnspr_lib_dir="${NSPR_BUILD_DIR}/dist/lib" \
+  -Dnspr_include_dir="${NSPR_BUILD_DIR}/dist/include/nspr" \
+  -Dnss_dist_dir="${BUILD_DIR}" \
+  -Dnss_dist_obj_dir="${BUILD_DIR}" \
+  -Dhost_arch="${GYP_ARCH}" \
+  -Dtarget_arch="${GYP_ARCH}" \
+  -Dstatic_libs=1 \
+  -Ddisable_dbm=1 \
+  -Dsign_libs=0 \
+  -Denable_sslkeylogfile=0 \
+  -Ddisable_tests=1 \
+  -Ddisable_libpkix=1 \
+  -Diphone_deployment_target="${IOS_MIN_SDK_VERSION}"
+
+GENERATED_DIR="${NSS_SRC_DIR}/nss/out/Release-$(echo ${OS_COMPILER} | tr '[:upper:]' '[:lower:]')/"
+ninja -C "${GENERATED_DIR}"
+
+mkdir -p "${DIST_DIR}/include/nss"
+mkdir -p "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/lib/libcertdb.a" "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/lib/libcerthi.a" "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/lib/libcryptohi.a" "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/lib/libfreebl_static.a" "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/lib/libmozpkix.a" "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/lib/libnss_static.a" "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/lib/libnssb.a" "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/lib/libnssdev.a" "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/lib/libnsspki.a" "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/lib/libnssutil.a" "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/lib/libpk11wrap_static.a" "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/lib/libpkcs12.a" "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/lib/libpkcs7.a" "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/lib/libsmime.a" "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/lib/libsoftokn_static.a" "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/lib/libssl.a" "${DIST_DIR}/lib"
+# HW specific.
+if [[ "${ARCH}" == "x86_64" ]]; then
+  cp -p -L "${BUILD_DIR}/lib/libgcm-aes-x86_c_lib.a" "${DIST_DIR}/lib"
+  cp -p -L "${BUILD_DIR}/lib/libhw-acc-crypto-avx.a" "${DIST_DIR}/lib"
+  cp -p -L "${BUILD_DIR}/lib/libhw-acc-crypto-avx2.a" "${DIST_DIR}/lib"
+  cp -p -L "${BUILD_DIR}/lib/libsha-x86_c_lib.a" "${DIST_DIR}/lib"
+elif [[ "${ARCH}" == "arm64" ]]; then
+  cp -p -L "${BUILD_DIR}/lib/libgcm-aes-aarch64_c_lib.a" "${DIST_DIR}/lib"
+  cp -p -L "${BUILD_DIR}/lib/libarmv8_c_lib.a" "${DIST_DIR}/lib"
+fi
+cp -p -L "${NSPR_BUILD_DIR}/dist/lib/libplc4.a" "${DIST_DIR}/lib"
+cp -p -L "${NSPR_BUILD_DIR}/dist/lib/libplds4.a" "${DIST_DIR}/lib"
+cp -p -L "${NSPR_BUILD_DIR}/dist/lib/libnspr4.a" "${DIST_DIR}/lib"
+
+cp -p -L -R "${BUILD_DIR}/public/nss/"* "${DIST_DIR}/include/nss"
+cp -p -L -R "${NSPR_BUILD_DIR}/dist/include/nspr/"* "${DIST_DIR}/include/nss"

--- a/automation/build-docs/overwrites/build-nss-ios.sh
+++ b/automation/build-docs/overwrites/build-nss-ios.sh
@@ -98,16 +98,8 @@ cp -p -L "${BUILD_DIR}/lib/libpkcs7.a" "${DIST_DIR}/lib"
 cp -p -L "${BUILD_DIR}/lib/libsmime.a" "${DIST_DIR}/lib"
 cp -p -L "${BUILD_DIR}/lib/libsoftokn_static.a" "${DIST_DIR}/lib"
 cp -p -L "${BUILD_DIR}/lib/libssl.a" "${DIST_DIR}/lib"
-# HW specific.
-if [[ "${ARCH}" == "x86_64" ]]; then
-  cp -p -L "${BUILD_DIR}/lib/libgcm-aes-x86_c_lib.a" "${DIST_DIR}/lib"
-  cp -p -L "${BUILD_DIR}/lib/libhw-acc-crypto-avx.a" "${DIST_DIR}/lib"
-  cp -p -L "${BUILD_DIR}/lib/libhw-acc-crypto-avx2.a" "${DIST_DIR}/lib"
-  cp -p -L "${BUILD_DIR}/lib/libsha-x86_c_lib.a" "${DIST_DIR}/lib"
-elif [[ "${ARCH}" == "arm64" ]]; then
-  cp -p -L "${BUILD_DIR}/lib/libgcm-aes-aarch64_c_lib.a" "${DIST_DIR}/lib"
-  cp -p -L "${BUILD_DIR}/lib/libarmv8_c_lib.a" "${DIST_DIR}/lib"
-fi
+cp -p -L "${BUILD_DIR}/lib/libgcm-aes-aarch64_c_lib.a" "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/lib/libarmv8_c_lib.a" "${DIST_DIR}/lib"
 cp -p -L "${NSPR_BUILD_DIR}/dist/lib/libplc4.a" "${DIST_DIR}/lib"
 cp -p -L "${NSPR_BUILD_DIR}/dist/lib/libplds4.a" "${DIST_DIR}/lib"
 cp -p -L "${NSPR_BUILD_DIR}/dist/lib/libnspr4.a" "${DIST_DIR}/lib"

--- a/automation/build-docs/overwrites/build-xcframework.sh
+++ b/automation/build-docs/overwrites/build-xcframework.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# This script builds the Rust crate in its directory into a staticlib XCFramework for iOS.
+
+BUILD_PROFILE="release"
+FRAMEWORK_NAME="MozillaRustComponents"
+IS_FOCUS=
+# FRAMEWORK_FILENAME exist purely because we would like to ship
+# multiple frameworks that have the same swift code
+# namely for focus. However, components that use
+# uniffi, can only declare a single framework name.
+#
+# So we keep the framework the same, but store them
+# under different file names.
+FRAMEWORK_FILENAME=$FRAMEWORK_NAME
+while [[ "$#" -gt 0 ]]; do case $1 in
+  --build-profile) BUILD_PROFILE="$2"; shift;shift;;
+  --framework-name) FRAMEWORK_NAME="$2"; shift;shift;;
+  *) echo "Unknown parameter: $1"; exit 1;
+esac; done
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+WORKING_DIR=$THIS_DIR
+REPO_ROOT="$( dirname "$( dirname "$THIS_DIR" )" )"
+
+MANIFEST_PATH="$WORKING_DIR/Cargo.toml"
+
+if [[ ! -f "$MANIFEST_PATH" ]]; then
+  echo "Could not locate Cargo.toml in $MANIFEST_PATH"
+  exit 1
+fi
+
+CRATE_NAME=$(grep --max-count=1 '^name =' "$MANIFEST_PATH" | cut -d '"' -f 2)
+if [[ -z "$CRATE_NAME" ]]; then
+  echo "Could not determine crate name from $MANIFEST_PATH"
+  exit 1
+fi
+
+LIB_NAME="lib${CRATE_NAME}.a"
+
+####
+##
+## 1) Build the rust code individually for each target architecture.
+##
+####
+
+# Helper to run the cargo build command in a controlled environment.
+# It's important that we don't let environment variables from the user's default
+# desktop build environment leak into the iOS build, otherwise it might e.g.
+# link against the desktop build of NSS.
+
+CARGO="$HOME/.cargo/bin/cargo"
+LIBS_DIR="$REPO_ROOT/libs"
+
+DEFAULT_RUSTFLAGS=""
+BUILD_ARGS=(build --manifest-path "$MANIFEST_PATH" --lib)
+case $BUILD_PROFILE in
+  debug) ;;
+  release)
+    BUILD_ARGS=("${BUILD_ARGS[@]}" --release)
+    # With debuginfo, the zipped artifact quickly balloons to many
+    # hundred megabytes in size. Ideally we'd find a way to keep
+    # the debug info but in a separate artifact.
+    DEFAULT_RUSTFLAGS="-C debuginfo=0"
+    ;;
+  *) echo "Unknown build profile: $BUILD_PROFILE"; exit 1;
+esac
+
+cargo_build () {
+  TARGET=$1
+  case $TARGET in
+    aarch64-apple-ios)
+      LIBS_DIR="$REPO_ROOT/libs/ios/arm64";;
+    *)
+      echo "Unexpected target architecture: $TARGET" && exit 1;;
+  esac
+  env -i \
+    NSS_STATIC=1 \
+    NSS_DIR="$LIBS_DIR/nss" \
+    PATH="${PATH}" \
+    RUSTC_WRAPPER="${RUSTC_WRAPPER:-}" \
+    SCCACHE_IDLE_TIMEOUT="${SCCACHE_IDLE_TIMEOUT:-}" \
+    SCCACHE_CACHE_SIZE="${SCCACHE_CACHE_SIZE:-}" \
+    SCCACHE_ERROR_LOG="${SCCACHE_ERROR_LOG:-}" \
+    RUST_LOG="${RUST_LOG:-}" \
+    RUSTFLAGS="${RUSTFLAGS:-$DEFAULT_RUSTFLAGS}" \
+    "$CARGO" "${BUILD_ARGS[@]}" --target "$TARGET"
+}
+
+set -euvx
+
+# Hardware iOS targets
+cargo_build aarch64-apple-ios
+
+# TODO: would it be useful to also include desktop builds here?
+# It might make it possible to run the Swift tests via `swift test`
+# rather than through Xcode.
+
+####
+##
+## 2) Stitch the individual builds together an XCFramework bundle.
+##
+####
+
+TARGET_DIR="$REPO_ROOT/target"
+XCFRAMEWORK_ROOT="$WORKING_DIR/$FRAMEWORK_FILENAME.xcframework"
+
+# Start from a clean slate.
+
+rm -rf "$XCFRAMEWORK_ROOT"
+
+# Build the directory structure right for an individual framework.
+# Most of this doesn't change between architectures.
+
+COMMON="$XCFRAMEWORK_ROOT/common/$FRAMEWORK_NAME.framework"
+
+mkdir -p "$COMMON/Modules"
+cp "$WORKING_DIR/module.modulemap" "$COMMON/Modules/"
+
+cp "$WORKING_DIR/DEPENDENCIES.md" "$COMMON/DEPENDENCIES.md"
+
+mkdir -p "$COMMON/Headers"
+
+# First we move the files that are common between both
+# firefox-ios and Focus
+cp "$WORKING_DIR/$FRAMEWORK_NAME.h" "$COMMON/Headers"
+cp "$REPO_ROOT/components/viaduct/ios/RustViaductFFI.h" "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/remote_settings/src/remote_settings.udl" -l swift -o "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/nimbus/src/nimbus.udl" -l swift -o "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/support/error/src/errorsupport.udl" -l swift -o "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/support/rust-log-forwarder/src/rust_log_forwarder.udl" -l swift -o "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/crashtest/src/crashtest.udl" -l swift -o "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/fxa-client/src/fxa_client.udl" -l swift -o "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/logins/src/logins.udl" -l swift -o "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/autofill/src/autofill.udl" -l swift -o "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/push/src/push.udl" -l swift -o "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/tabs/src/tabs.udl" -l swift -o "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/places/src/places.udl" -l swift -o "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/suggest/src/suggest.udl" -l swift -o "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/sync_manager/src/syncmanager.udl" -l swift -o "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/sync15/src/sync15.udl" -l swift -o "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/as-ohttp-client/src/as_ohttp_client.udl" -l swift -o "$COMMON/Headers"
+
+rm -rf "$COMMON"/Headers/*.swift
+
+# Flesh out the framework for each architecture based on the common files.
+# It's a little fiddly, because we apparently need to put all the simulator targets
+# together into a single fat binary, but keep the hardware target separate.
+# (TODO: we should try harder to see if we can avoid using `lipo` here, eliminating it
+# would make the overall system simpler to understand).
+
+# iOS hardware
+mkdir -p "$XCFRAMEWORK_ROOT/ios-arm64"
+cp -r "$COMMON" "$XCFRAMEWORK_ROOT/ios-arm64/$FRAMEWORK_NAME.framework"
+cp "$TARGET_DIR/aarch64-apple-ios/$BUILD_PROFILE/$LIB_NAME" "$XCFRAMEWORK_ROOT/ios-arm64/$FRAMEWORK_NAME.framework/$FRAMEWORK_NAME"
+
+
+# Set up the metadata for the XCFramework as a whole.
+
+cp "$WORKING_DIR/Info.plist" "$XCFRAMEWORK_ROOT/Info.plist"
+cp "$WORKING_DIR/DEPENDENCIES.md" "$XCFRAMEWORK_ROOT/DEPENDENCIES.md"
+
+rm -rf "$XCFRAMEWORK_ROOT/common"
+
+# Zip it all up into a bundle for distribution.
+
+(cd "$WORKING_DIR" && zip -9 -r "$FRAMEWORK_FILENAME.xcframework.zip" "$FRAMEWORK_FILENAME.xcframework")

--- a/automation/build-docs/overwrites/verify-ios-ci-environment.sh
+++ b/automation/build-docs/overwrites/verify-ios-ci-environment.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Ensure the build toolchains are set up correctly for iOS builds.
+#
+# This is intended for use in CI, so it verifies only the minimum that is needed
+# to build in CI. For local development use `verify-ios-environment.sh`.
+#
+# This file should be used via `./libs/verify-ios-ci-environment.sh`.
+
+set -e
+
+RUST_TARGETS=("aarch64-apple-ios")
+
+if [[ ! -f "$(pwd)/libs/build-all.sh" ]]; then
+  echo "ERROR: verify-ios-ci-environment.sh should be run from the root directory of the repo"
+  exit 1
+fi
+
+"$(pwd)/libs/verify-common.sh"
+
+rustup target add "${RUST_TARGETS[@]}"
+
+# If you add a dependency below, mention it in building.md in the iOS section!
+
+if ! [[ -x "$(command -v xcpretty)" ]]; then
+  echo 'Error: xcpretty needs to be installed. See https://github.com/xcpretty/xcpretty#installation for install instructions.' >&2
+  exit 1
+fi
+
+if [[ ! -d "${PWD}/libs/ios/universal/nss" ]]; then
+  pushd libs || exit 1
+  ./build-all.sh ios
+  popd || exit 1
+fi

--- a/automation/build-docs/rename-and-update.sh
+++ b/automation/build-docs/rename-and-update.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Set locale to UTF-8 to avoid illegal byte sequence errors
+export LC_CTYPE=C
+export LANG=C
+
+STATIC_FILES_FOLDER_PATH="./docs-website"
+
+# Find all files with colons in their names, rename them, and update references
+find $STATIC_FILES_FOLDER_PATH -depth -name '*:*' \
+| while IFS= read -r file; do
+    # Generate the new name by replacing colons with underscores
+    new_name="$(dirname "$file")/$(basename "$file" | tr ':' '_')"
+    
+    # Rename the file
+    mv "$file" "$new_name"
+
+    # Escape slashes and special characters for sed
+    escaped_file=$(printf '%s\n' "$(basename "$file")" | sed 's/[][\\/.^$*]/\\&/g')
+    escaped_new_name=$(printf '%s\n' "$(basename "$new_name")" | sed 's/[][\\/.^$*]/\\&/g')
+    
+    # Update only the specific references to the renamed file within the documentation
+    grep -rl "$escaped_file" $STATIC_FILES_FOLDER_PATH \
+    | xargs sed -i '' "s/$escaped_file/$escaped_new_name/g"
+done


### PR DESCRIPTION
The initial idea for this PR comes from wanting better documentation around [UniFFI](https://github.com/mozilla/uniffi-rs).

Since this repo is handling building the `swift` components from `application-services`, this is the right place to facilitate this endeavor. We have loosely coupled `.swift` files we would like to get documentation out and serve them on a web server. 

However, Swift is not allowing us to strip-out the doc comments and serve them on as a static website.

These are the steps involved:

- [x]  We have to find the right `Package.swift` setup so we are able to build a full project. The existing one (from `application-services`) is not able to do so.
- [x] Generate a `.xcframework` file from an existing `application-services` repository.
- [x] Swift is using [DocC](https://www.swift.org/documentation/docc/documenting-a-swift-framework-or-package) as their documentation model, which is tightly integrated in XCode. We need to find CLI tools which can take a `.xcodeproject` file and generate a `.doccarchive`
- [x] Out of a `.doccarchive`, which can be browsed through locally, we need to generate a static-website.
- [x] To be able to build `application-services`, we need to find the right CI/CD environment to build the NSS package + the XCode dependencies
- [x] Once the `.xcodeproject` file is generated, we need to be able to generate a `.doccarchive` in the CI/CD workflow and generate static website files from it
- [x] Once this is generated, we push the static website files to a new branch
- [ ] We have to sanitize the folder and file names somehow...

All files are under `automation/build-docs`.

## Milestones

* I adapted the `Package.swift` file to add `Glean` as a dependency, and updated it to `iOSv15`. Afterwards, I was able to build a `.xcodeproject` from a local `application-services` project.
* XCode comes with CLI tools to build both a `.doccarchive` and generate a static website from it:
```
$ xcodebuild docbuild -scheme $SCHEME -destination $DESTINATION -derivedDataPath $OUTPUT_DIR

$ xcrun docc process-archive transform-for-static-hosting $DOCC_ARCHIVE_PATH --output-path $STATIC_FILES_FOLDER --hosting-base-path $HOSTING_PATH
```

## Moving this to the CI/CD platform, there are many, many challenges:

* We need to find the right combination of Python and XCode version so the NSS library builds successfully.
* There are many system dependencies we need to install, which was sometimes interfering with the standard `brew` installation of `Python`.
* `application-services` comes with build scripts, which will install `x86_64`, and `arm64` dependencies. As well as it installs the `ios-simulator` target on `x86_64`, which broke the countless builds in many different ways. 

The only solution I could see was to "overwrite" the build scripts from `application-services` and apply them during build time in the GitHub workflow:

```bash
cp ./automation/build-docs/overwrites/build-all-ios.sh /tmp/application-services/libs/
cp ./automation/build-docs/overwrites/build-nss-ios.sh /tmp/application-services/libs/
cp ./automation/build-docs/overwrites/verify-ios-ci-environment.sh /tmp/application-services/libs/   
cp ./automation/build-docs/overwrites/build-and-test-swift.py /tmp/application-services/taskcluster/scripts/
cp ./automation/build-docs/overwrites/build-xcframework.sh /tmp/application-services/megazords/ios-rust/
```

These overwrites remove all `ios-simulator` and `x86_64` targets, and just build for `arm64`. 

We then can go ahead and setup the build environment:

```bash
cd /tmp/application-services
./libs/verify-ios-ci-environment.sh
```

# Roadblock

Folder and file names of the generated static website contain not valid characters:

```
Run actions/upload-artifact@v3
...
Artifact name is valid!
Error: Artifact path is not valid: /data/documentation/mozillaappservices/accesstokeninfo/!=(_:_:).json. Contains the following character:  Colon :
          
Invalid characters include:  Double quote ", Colon :, Less than <, Greater than >, Vertical bar |, Asterisk *, Question mark ?, Carriage return \r, Line feed \n
```

Many folders and files are named `!=(_:_:)`, and `:` is not allowed as part of the filename. 