### PR TITLE
ci: switch Taskcluster trust domain to 'app-services'

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -11,7 +11,7 @@ policy:
     pullRequests: public
 tasks:
     - $let:
-          trustDomain: "mozilla"
+          trustDomain: app-services
           ownerEmail:
               $switch:
                   'tasks_for == "github-push"': '${event.pusher.email}'

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -1,9 +1,9 @@
 ---
-trust-domain: "mozilla"
+trust-domain: app-services
 task-priority: low
 
 taskgraph:
-  cached-task-prefix: "mozilla.v2.rust-components-swift"
+  cached-task-prefix: "app-services.v2.rust-components-swift"
   repositories:
     rust_components_swift:
       name: "rust-components-swift"


### PR DESCRIPTION
This will allow this repo to use many of the same resources (workers, secrets, scopes etc) as the mozilla/application-services repo.